### PR TITLE
Import as bookmarks

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -1,0 +1,392 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><H3 PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Bar</H3>
+    <DL><p>
+        <DT><H3>Tech Starter Packs</H3>
+        <DL><p>
+            <DT><H3>AI, ML & Data</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/nimobeeren.com/3l7i7ciwnt22v">AI ML data frens</A>
+                <DT><A HREF="https://bsky.app/starter-pack/pelayoarbues.com/3l7gammw22z2c">AI & Data</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/r5eVvT">Health, AI, and Informatics</A>
+                <DT><A HREF="https://bsky.app/starter-pack/arynn.bsky.social/3l7ln7qrrj22b">Nice Data People</A>
+                <DT><A HREF="https://bsky.app/starter-pack/sharky6000.bsky.social/3l7kt6xwjqe2n">Google DeepMind</A>
+                <DT><A HREF="https://bsky.app/starter-pack/pelayoarbues.com/3l7isybcp522s">ML/AI Researchers</A>
+                <DT><A HREF="https://go.bsky.app/5388qNY">Data Ladies</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/F7m9rBy">RecSys</A>
+                <DT><A HREF="https://bsky.app/starter-pack/cpaxton.bsky.social/3lampx4vqrv24">Robotics & AI</A>
+            </DL><p>
+            <DT><H3>Cloud</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/profile/pelayoarbues.com/post/3l7nx4mbjta2s">Infrastructure Engineers</A>
+            </DL><p>
+            <DT><H3># AWS</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/gunnargrosch.com/3l7iniq54362z">AWS Developer Experience</A>
+                <DT><A HREF="https://bsky.app/starter-pack/tobilg.com/3l7gkycyvc52t">AWS Serverless</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/EZ7AYrd">AWS Heros</A>
+                <DT><A HREF="https://go.bsky.app/NFaJFWC">AWS Community Builders</A>
+            </DL><p>
+            <DT><H3># Azure</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/rios.engineer/3laoclx5ddm2q">Azure Bicep</A>
+                <DT><A HREF="https://bsky.app/starter-pack/mestredelpino.com/3l7lb4zf7672h">Azure Kubernetes Service Champs</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/FkPKwkK">Microsoft Cloud Security & Identity</A>
+            </DL><p>
+            <DT><H3># Cloudflare</H3>
+            <DL><p>
+                <DT><A HREF="https://go.bsky.app/8nnY28Q">Cloudflare Developer Platform</A>
+            </DL><p>
+            <DT><H3># Google Cloud</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack-short/HKkrgZb">Google Cloud Developer Relations</A>
+            </DL><p>
+            <DT><H3>Communities</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack-short/DFvXfF5">Diversify Tech's starter pack</A>
+                <DT><A HREF="https://bsky.app/starter-pack/aliafonzy.bsky.social/3l6xfjc56jc2m">Black Tech Peeps</A>
+                <DT><A HREF="https://bsky.app/starter-pack/nerdyandnoteworthy.bsky.social/3law262cfob2y">Black Tech Voices</A>
+                <DT><A HREF="https://bsky.app/starter-pack/minamarkh.am/3laqyfejjzf2l">Black Women in Tech</A>
+                <DT><A HREF="https://bsky.app/starter-pack/annthurium.bsky.social/3lb3qde3b6o2j">Non-binary technologists</A>
+                <DT><A HREF="https://bsky.app/starter-pack/annaspies.bsky.social/3l7qqknfnm72n">Women in Tech</A>
+                <DT><A HREF="https://bsky.app/starter-pack/salesforcestacey.bsky.social/3lb35aj2oyk2w">Women in Tech (Salesforce-focused)</A>
+            </DL><p>
+            <DT><H3># Africa</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/singe.bsky.social/3lau2uti7rh27">ZA Hackers</A>
+            </DL><p>
+            <DT><H3># Europe</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/hellonehha.bsky.social/3lavoqqajkt23">London Tech Community</A>
+                <DT><A HREF="https://bsky.app/starter-pack/danielfos.co/3lay66ikx3525">Netherlands Tech Community</A>
+            </DL><p>
+            <DT><H3># North America</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/jerdog.dev/3lavvs6vyuj2j">Kansas City Tech Community</A>
+                <DT><A HREF="https://bsky.app/starter-pack/toddhgardner.com/3lazwzq2yxi2g">Minnesota Tech</A>
+                <DT><A HREF="https://bsky.app/starter-pack/jade0x.dev/3laymntlqbc23">Texas Tech</A>
+                <DT><A HREF="https://bsky.app/starter-pack/benv.ca/3lax54fdgjj22">Toronto Tech Community</A>
+            </DL><p>
+            <DT><H3>Corporate Community Programs</H3>
+            <DL><p>
+                <DT><A HREF="https://go.bsky.app/TGLWrCC">Docker Captains</A>
+                <DT><A HREF="https://go.bsky.app/EuKURBU">Microsoft MVPs</A>
+            </DL><p>
+            <DT><H3>Conference Related</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/justingarrison.com/3l74pjn6n3d26">All Things Open 2024 speakers</A>
+                <DT><A HREF="https://bsky.app/starter-pack/jesstemporal.com/3l7ljmricf22o">Github Stars #githubuniverse</A>
+                <DT><A HREF="https://bsky.app/starter-pack/ruyadorno.bsky.social/3l7xylnqftc2d">Nodeconf EU 2024</A>
+                <DT><A HREF="https://bsky.app/starter-pack/iamrajiv.bsky.social/3laxkxyprg32a">Technical Conferences</A>
+            </DL><p>
+            <DT><H3>DBs, BI, & Geo</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/crunchydata.com/3l7lifgrswr2d">PostGIS</A>
+                <DT><A HREF="https://bsky.app/starter-pack/craigkerstiens.com/3l72fsuwbnu26">Postgres People</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/8TdEfdK">Data People Starter Pack</A>
+                <DT><A HREF="https://bsky.app/starter-pack/tobilg.com/3l7ggytb2kz2j">DuckDB</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/PGYLmPG">Open Source Geospatial</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/F7m9rBy">Oracle Folks</A>
+                <DT><A HREF="https://bsky.app/starter-pack/darraghmurray.bsky.social/3l7zwvzcfcc2l">Tableau</A>
+            </DL><p>
+            <DT><H3>DevEx & UI</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/profile/joebell.studio/post/3l7s7pjyk5v2w">UI</A>
+                <DT><A HREF="https://bsky.app/starter-pack/spavel.bsky.social/3kzmdo5tt4a2c">UX</A>
+            </DL><p>
+            <DT><H3>GameDev</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/thoughtrise.bsky.social/3l7lf3thjxp2i">Women Leaders in Games</A>
+                <DT><A HREF="https://linseyray.notion.site/BlueSky-GameDev-Starter-Packs-12721c74d80380b8ba81d95d01c8d9d6">BlueSky GameDev Starter Packs</A>
+                <DT><A HREF="https://bsky.app/starter-pack/annamegill.com/3l7jfmsxuh42z">AAA Game Writers</A>
+                <DT><A HREF="https://bsky.app/starter-pack/timjung.bsky.social/3l77am5e7yg2e">Engineers/Programmers in the Gaming Industry</A>
+                <DT><A HREF="https://bsky.app/starter-pack/rafikidev.bsky.social/3l7ja7gdbdh2k">VR Game Devs</A>
+            </DL><p>
+            <DT><H3>Kubernetes & Cloud Native</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack-short/RCerxDE">Cloud Native</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/GbZUjph">Cloud Native Projects</A>
+                <DT><A HREF="https://bsky.app/starter-pack/starefossen.bsky.social/3l73umo3tyl27">CNCF Ambassadors</A>
+                <DT><A HREF="https://go.bsky.app/E8JcNAk">CNCF Kubestronauts</A>
+                <DT><A HREF="https://bsky.app/starter-pack/me.nzen.ski/3la7hu6g3aw2d">CNCF Platform Working Group</A>
+                <DT><A HREF="https://bsky.app/starter-pack/ahmet.dev/3l7tozhy6s42f">Kubernetes Engineering</A>
+            </DL><p>
+            <DT><H3>History of Technology</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/karstenuhl.bsky.social/3lb3sv3hgmz2i">History of Technology</A>
+            </DL><p>
+            <DT><H3>Infrastructure as Code</H3>
+            <DL><p>
+                <DT><A HREF="https://go.bsky.app/FEpXrbj">Hashicorp Ambassadors</A>
+                <DT><A HREF="https://bsky.app/starter-pack/ediri.de/3l7xy7rgl2h2n">Pulumi</A>
+            </DL><p>
+            <DT><H3>Marketing/Growth/DevRel</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack-short/VrJki2f">Tech Marketing</A>
+                <DT><A HREF="https://bsky.app/starter-pack/ladyofcode.com/3l7l3savfr62w">DevRel/DX Engineers & Developer Advocates</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/3vZbY9h">DevRel</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/VDeVSBW">Developer Relations</A>
+                <DT><A HREF="https://bsky.app/starter-pack/chrzanowski.info/3la2ubcmclv2o">JetBrains Developer Advocates</A>
+            </DL><p>
+            <DT><H3>Mobile</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/mmckenna.me/3l77ynyeo6f2q">Android Dev</A>
+                <DT><A HREF="https://go.bsky.app/RoyGvDb">iOS and Mac Developers</A>
+            </DL><p>
+            <DT><H3>Networking</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/andraste.fuckbgp.com/3l6xcx4veuz2v">Network Engineering</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/TLhL2HV">Packet Herders</A>
+            </DL><p>
+            <DT><H3>News</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/cdteu.bsky.social/3layaqy7snj2l">EU Tech Journalists</A>
+                <DT><A HREF="https://bsky.app/starter-pack/niallfirth.bsky.social/3lavll7orvm2q">Tech Journalists</A>
+                <DT><A HREF="https://bsky.app/starter-pack/mattkeil.com/3law3bhnotm2k">Tech News and Opinions</A>
+            </DL><p>
+            <DT><H3>Observability</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/metalmatze.de/3la6tkzai4b2n">Prometheus </A>
+            </DL><p>
+            <DT><H3>Open Source</H3>
+            <DL><p>
+                <DT><A HREF="https://go.bsky.app/BrzaZ72">Open Source Starter Pack</A>
+                <DT><A HREF="https://bsky.app/starter-pack/jordienric.com/3l7tavlwjww25">Open Source</A>
+                <DT><A HREF="https://bsky.app/starter-pack/kelset.dev/3l7vrkvoxh225">The World Of Open Source</A>
+            </DL><p>
+            <DT><H3>Platforms</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/mergesort.me/3l7chd3ifs42f">Apple Developers</A>
+                <DT><A HREF="https://bsky.app/starter-pack/jeehut.bsky.social/3lbhexvpgvx27">Indie Apple Platform Developers</A>
+                <DT><A HREF="https://bsky.app/starter-pack/cecallihelper.bsky.social/3laqvysnuls2x">Bluesky team, dev, tips, tools</A>
+                <DT><A HREF="https://bsky.app/starter-pack/ghost.org/3l7fhntjiw32n">Ghost Devs</A>
+                <DT><A HREF="https://go.bsky.app/QfxgKsf">AtProto Devs</A>
+                <DT><A HREF="https://bsky.app/starter-pack/samuel.bsky.team/3kztso5fnic24">Protocol Pals (atproto)</A>
+            </DL><p>
+            <DT><H3>Platform Engineering & Devops</H3>
+            <DL><p>
+                <DT><A HREF="https://go.bsky.app/SVTURgj">Platform Engineering</A>
+                <DT><A HREF="https://go.bsky.app/2WcJHj1">DevOps</A>
+            </DL><p>
+            <DT><H3>Programming Languages</H3>
+            <DL><p>
+            </DL><p>
+            <DT><H3># Clojure</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack-short/Mj51mWX">Bluesky Clojure Community</A>
+            </DL><p>
+            <DT><H3># Dart</H3>
+            <DL><p>
+                <DT><A HREF="https://go.bsky.app/EzEZLU7">Flutter Dev Starter Pack</A>
+            </DL><p>
+            <DT><H3># .Net</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/bensampica.com/3l77ymcm23h25">dotnet</A>
+                <DT><A HREF="https://bsky.app/starter-pack/tunaxor.me/3l7vgqm56z42s">F# and dotnet folks</A>
+            </DL><p>
+            <DT><H3># Elixir</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack-short/HL9mNDS">Elixir devs</A>
+            </DL><p>
+            <DT><H3># Elm</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/taylor.town/3lbhxsc4j252d">Elm Community</A>
+            </DL><p>
+            <DT><H3># Functional Programming</H3>
+            <DL><p>
+                <DT><A HREF="https://go.bsky.app/Tkj4hAZ">Functional Programming</A>
+            </DL><p>
+            <DT><H3># Go</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/mvdan.cc/3l7lat3zdug2o">Go Contributors</A>
+                <DT><A HREF="https://bsky.app/starter-pack/mvdan.cc/3l7lat3zdug2o">Gophers</A>
+                <DT><A HREF="https://bsky.app/starter-pack/dario.cat/3la7ixru2fj2w">Gophers in the Bluesky</A>
+            </DL><p>
+            <DT><H3># Java</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/alina-yurenko.bsky.social/3lao6szrmiz2x">GraalVM Team</A>
+                <DT><A HREF="https://bsky.app/starter-pack/chrzanowski.info/3la5a2ojmnw2r">Java Champions</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/F7m9rBy">Java and JVM</A>
+            </DL><p>
+            <DT><H3># Julia</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack-short/GgS24Fv">Julia Lang</A>
+            </DL><p>
+            <DT><H3># Kotlin</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack-short/2oR84o6">Kotlin Multiplatform</A>
+                <DT><A HREF="https://go.bsky.app/BV8HXZ1">Kotlin Folks</A>
+            </DL><p>
+            <DT><H3># Nix/NixOS</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/handle.invalid/3lau2ctouup2x">Nix/NixOS</A>
+            </DL><p>
+            <DT><H3># PowerShell</H3>
+            <DL><p>
+                <DT><A HREF="https://go.bsky.app/9ozmoAY">PowerShell Community</A>
+            </DL><p>
+            <DT><H3># Python</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/savannah.dev/3l7y3twh7xm2l">Python</A>
+                <DT><A HREF="https://bsky.app/starter-pack/cosima.bsky.social/3l7zmdn5tsp26">Pyladies</A>
+                <DT><A HREF="https://bsky.app/starter-pack/jesper.drams.ch/3l7j6coaqcr2z">Pythonistas</A>
+                <DT><A HREF="https://bsky.app/starter-pack/hugovk.bsky.social/3lat5bsw4ar2h">Python Core Team</A>
+                <DT><A HREF="https://bsky.app/starter-pack/monorepo.bsky.social/3lacjuhrjlp2o">Python Software Foundation and Friends</A>
+                <DT><A HREF="https://bsky.app/starter-pack/adamghill.com/3l6yeskolfm27">Django web framework</A>
+                <DT><A HREF="https://bsky.app/starter-pack/hugovk.bsky.social/3lat5bsw4ar2h">Python Core Developers</A>
+                <DT><A HREF="https://bsky.app/starter-pack/lernerpython.com/3latidjifnf2l">Python authors, speakers, and teachers</A>
+            </DL><p>
+            <DT><H3># Ruby and Rails</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/joshuawood.net/3kw3olx5gf72m">Ruby and Rails</A>
+                <DT><A HREF="https://bsky.app/starter-pack/bradgessler.com/3lajohae7te2c">Built with Ruby and Rails</A>
+                <DT><A HREF="https://bsky.app/starter-pack/rowen.willabus.com/3lbdwu5kve323">Ruby Contributors</A>
+                <DT><A HREF="https://bsky.app/starter-pack/rowen.willabus.com/3lb3p673jqq27">Rails Contributors</A>
+            </DL><p>
+            <DT><H3># Rust</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/jameseastham.co.uk/3la6thx4xbq2l">Rust Devs</A>
+                <DT><A HREF="https://bsky.app/starter-pack/schmizz.net/3l7l572b6xr2w">Rustaceans</A>
+            </DL><p>
+            <DT><H3># Scala</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/salarrahmanian.bsky.social/3laq4c2o4a42a">Scala</A>
+            </DL><p>
+            <DT><H3># Swift</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/peterfriese.dev/3lbhdr4ntnz2s">Swift / iOS Community</A>
+            </DL><p>
+            <DT><H3># Typescript</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/maikelkrause.bsky.social/3lalqx3qepb2r">Effect-TS Community</A>
+                <DT><A HREF="https://bsky.app/starter-pack/netopia.bsky.social/3lavvqswa5723">EU Digital Policy & Tech Regulation</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/84ChefN">OSS Typescript Maintainers</A>
+                <DT><A HREF="https://bsky.app/starter-pack/joshuakgoldberg.com/3la7gv7wa4722">Typescript and Static Analysis</A>
+            </DL><p>
+            <DT><H3>Policy/Public Interest/Criticism</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/jessicahullman.bsky.social/3l3tsz4gzk52t">Algorithmic decision-making</A>
+                <DT><A HREF="https://bsky.app/starter-pack/remmelt.bsky.social/3lanjabtnk22m">Counter Tech Power Grabs</A>
+                <DT><A HREF="https://bsky.app/starter-pack/parismarx.bsky.social/3lamkmrv72w2q">Critical Tech</A>
+                <DT><A HREF="https://bsky.app/starter-pack/martinstabe.bsky.social/3l373eyo7zq2u">Data Journalism</A>
+                <DT><A HREF="https://bsky.app/starter-pack/go-opendata.bsky.social/3laof5cm67q2m">Open Data</A>
+                <DT><A HREF="https://bsky.app/starter-pack/ashleyshoo.bsky.social/3lazzlsgdkj2u">Philosophy of Technology</A>
+                <DT><A HREF="https://bsky.app/starter-pack/stribs.bsky.social/3laokvt2u7u24">Privacy by Design</A>
+                <DT><A HREF="https://bsky.app/starter-pack/merbroussard.bsky.social/3lamcen2niz2x">Public Interest Technology</A>
+                <DT><A HREF="https://bsky.app/starter-pack/markscrivens.bsky.social/3landpgddiv2l">Tech Skeptics</A>
+            </DL><p>
+            <DT><H3>Retro Computing</H3>
+            <DL><p>
+                <DT><A HREF="https://go.bsky.app/yRapus">Home Computer</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/VEZLtHP">Retrocomputing</A>
+            </DL><p>
+            <DT><H3>Security</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/mooreds.com/3l7jlxbxam32s">Authentication/Identity Folks</A>
+                <DT><A HREF="https://bsky.app/starter-pack/rafikidev.bsky.social/3l7ja7gdbdh2k">Identity and Access Management</A>
+                <DT><A HREF="https://go.bsky.app/NRP3ecE">Hackers</A>
+                <DT><A HREF="https://bsky.app/starter-pack/lucky225.bsky.social/3lavihs56zq2w">Hackers & Phreakers</A>
+                <DT><A HREF="https://bsky.app/starter-pack/stonking.com/3l7trhx5kbr2u">Infosec Bluesky</A>
+                <DT><A HREF="https://bsky.app/starter-pack/patrickhowelloneill.com/3l3ef5norol2u">Cyber starter Pack</A>
+                <DT><A HREF="https://bsky.app/starter-pack/scriptingosx.bsky.social/3layijhvkt42x">MacAdmins</A>
+                <DT><A HREF="https://bsky.app/starter-pack/sanitybit.com/3l6mkk23cpn24">Security and Security Adjacent</A>
+                <DT><A HREF="https://bsky.app/starter-pack/mccune.org.uk/3layremkrkz2i">Web Application Security</A>
+                <DT><A HREF="https://bsky.app/starter-pack/0x0.boo/3lb4gtjtfq32i">Cybersecurity Starter Pack</A>
+                <DT><A HREF="https://go.bsky.app/J7ixyhL">The Cybersecurity Trainers</A>
+            </DL><p>
+            <DT><H3>Software Dev</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/devtools.fm/3l7uo2usby32x">Devtools FM</A>
+                <DT><A HREF="https://bsky.app/starter-pack/puerco.mx/3l7kaztw3vf27">Supply Chain Security</A>
+                <DT><A HREF="https://bsky.app/starter-pack/watwa.re/3lahegmecyl2b">Future of Coding</A>
+                <DT><A HREF="https://bsky.app/starter-pack/iamwil.bsky.social/3l7lg3xpvzk2g">Future of Programming</A>
+                <DT><A HREF="https://go.bsky.app/Tkj4hAZ">Functional Programming</A>
+                <DT><A HREF="https://go.bsky.app/7K2QAmW">Legacy Code Menders</A>
+                <DT><A HREF="https://go.bsky.app/DVX3b4h">Software Testing and Quality</A>
+                <DT><A HREF="https://go.bsky.app/Jn1NbRv">Software Development</A>
+            </DL><p>
+            <DT><H3>Software Engineering</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/profile/pelayoarbues.com/post/3l7nx4mbjta2s">Tech Managers</A>
+            </DL><p>
+            <DT><H3>Stats/Bio/R</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/jeremy-data.bsky.social/3l6x3agttsg2r">Rstats Starter Pack</A>
+                <DT><A HREF="https://bsky.app/profile/drmowinckels.bsky.social/post/3l76bxsdi7w2q">Dr. Mowinckel's rstats picks</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/Ha64Gmv">Bioconductor Bioinformatics #rstats</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/J98GoyE">ggplot2</A>
+                <DT><A HREF="https://bsky.app/profile/jeremy-data.bsky.social/post/3l7gsqpmup72q">Jeremy Allen's list of Starter Packs</A>
+                <DT><A HREF="https://bsky.app/starter-pack/noamross.net/3land3z3fez2z">rOpenSci</A>
+                <DT><A HREF="https://bsky.app/starter-pack/jeremy-data.bsky.social/3l6x3agttsg2r">Rstats Starter Pack</A>
+                <DT><A HREF="https://bsky.app/starter-pack/grrrck.xyz/3lahi4wmmkq2h">Shiny Devs</A>
+            </DL><p>
+            <DT><H3>Startups</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/joshuawood.net/3l72a55j7kq2s">Founders and Bootstrappers</A>
+                <DT><A HREF="https://bsky.app/starter-pack/berksky.bsky.social/3l7dbwlvzap2z">Indie Saas Founders</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/T3kv9A8">Indie Founders</A>
+                <DT><A HREF="https://bsky.app/starter-pack/ruurtjan.bsky.social/3lavnclprgm2r">Full-time bootstrapped tech founders</A>
+            </DL><p>
+            <DT><H3>Systems Engineering</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/chris.blue/3l7cfdtapwz2l">Infrastructure Engineers </A>
+                <DT><A HREF="https://bsky.app/starter-pack/embano1.mgasch.com/3l7i37p3prf2p">Distributed Systems</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/GgS24Fv">eBPF</A>
+                <DT><A HREF="https://bsky.app/starter-pack/brancz.com/3l7j5vpnytv26">Observability</A>
+                <DT><A HREF="https://bsky.app/starter-pack/vonneudeck.com/3l7m7hb7fnp24">Resilience Engineering</A>
+            </DL><p>
+            <DT><H3>Tech Writing</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/chrissycodes.bsky.social/3lai47ekkon2o">Technical Writers</A>
+            </DL><p>
+            <DT><H3>Training/Education</H3>
+            <DL><p>
+                <DT><A HREF="https://go.bsky.app/8MFcCVm">Pluralsight Authors</A>
+            </DL><p>
+            <DT><H3>Virtual Reality</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/liv-lagger.bsky.social/3layl2af2kk2a">VR Game Developers and Publishers</A>
+            </DL><p>
+            <DT><H3>WWW</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/xzilja.bsky.social/3laq7ngknar2r">Dev Toolkit</A>
+                <DT><A HREF="https://bsky.app/starter-pack/sia.codes/3l7svus2jcz2b">Sia's 11ty</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/RVWSVqe">Sia's Frontend Web Performance</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/BNkzSpM">APIs you won't hate</A>
+                <DT><A HREF="https://bsky.app/profile/benjystanton.bsky.social/post/3l73f5ckmw52a">Angular</A>
+                <DT><A HREF="https://bsky.app/profile/did:plc:ggmzqo5qmqt53zu2ep4vdfhe/feed/aaam4fpfvsnie">Android Dev feed</A>
+                <DT><A HREF="https://go.bsky.app/B786XGA">Drupal folks</A>
+                <DT><A HREF="https://go.bsky.app/8nnY28Q">Front End and Web Dev</A>
+                <DT><A HREF="https://bsky.app/starter-pack/mijustin.bsky.social/3l75rwvv4ii24">Laravel Friends</A>
+                <DT><A HREF="https://go.bsky.app/PLks8fY">PHP / Laravel Dev Tools</A>
+                <DT><A HREF="https://go.bsky.app/A6biNib">CSS</A>
+                <DT><A HREF="https://bsky.app/starter-pack/benv.ca/3l7y3p7q2vs2q">Retro Webdev</A>
+                <DT><A HREF="https://go.bsky.app/hLveAd">Thead of Frontend Starter Packs</A>
+                <DT><A HREF="https://bsky.app/starter-pack/matamo.dev/3la7fif4zh42y">Web Design Inspiration</A>
+            </DL><p>
+            <DT><H3># WWW-related News</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/css-tricks.com/3la2jb3dtnv2h">Frontend Magazines</A>
+            </DL><p>
+            <DT><H3># React</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/mooreds.com/3l7jlxbxam32s">React Native</A>
+                <DT><A HREF="https://bsky.app/starter-pack/ralexanderson.com/3l74a3jou7h2k">Remix/React Router adjacent</A>
+            </DL><p>
+            <DT><H3># Svelte</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/stordahl.dev/3l7vxqtis6i2q">Svelte Fam</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/QEhPG3P">Svelte</A>
+            </DL><p>
+            <DT><H3># Vue</H3>
+            <DL><p>
+                <DT><A HREF="https://bsky.app/starter-pack/filrakow.ski/3l7syh6aqyk2s">Vue JS Starter</A>
+                <DT><A HREF="https://bsky.app/starter-pack-short/VsEJig">Vuesky JS</A>
+                <DT><A HREF="https://bsky.app/starter-pack/thealexlichter.com/3l7px6ilbvf2m">Vue and Nuxtjs Devs</A>
+            </DL><p>
+        </DL><p>
+    </DL><p>
+</DL><p>

--- a/bookmarks.jinja
+++ b/bookmarks.jinja
@@ -1,0 +1,20 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><H3 PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Bar</H3>
+    <DL><p>
+        <DT><H3>Tech Starter Packs</H3>
+        <DL><p>
+            {% for category, items in categories.items() %}
+            <DT><H3>{{ category }}</H3>
+            <DL><p>
+            {% for item in items %}
+                <DT><A HREF="{{ item.url }}">{{ item.title }}</A>
+            {% endfor %}
+            </DL><p>
+            {% endfor %}
+        </DL><p>
+    </DL><p>
+</DL><p>

--- a/bookmarks.py
+++ b/bookmarks.py
@@ -1,0 +1,53 @@
+import re
+from jinja2 import Environment, FileSystemLoader
+
+#
+# Generate a bookmarks.html file from the README.md file 
+# which can be imported inta a browser.
+#
+
+# Setup Jinja2 environment
+env = Environment(
+    loader=FileSystemLoader("."),
+    trim_blocks=True,
+    lstrip_blocks=True
+)
+template = env.get_template("bookmarks.jinja")
+
+# Read the markdown input from file
+with open("README.md", "r") as file:
+    markdown = file.read()
+
+# Omit everything before "## AI, ML & Data"
+start_marker = "## AI, ML & Data"
+if start_marker in markdown:
+    markdown = markdown[markdown.index(start_marker):]
+
+def parse_markdown(markdown):
+    lines = markdown.strip().split("\n")
+    category = None
+    parsed_data = {}
+
+    for line in lines:
+        if line.startswith("##"):
+            category = line[2:].strip()
+            parsed_data[category] = []
+        elif line.startswith("*") and category:
+            match = re.match(r"\* (.+?) <(.+?)>", line)
+            if match:
+                title, url = match.groups()
+                parsed_data[category].append({"title": title, "url": url})
+
+    return parsed_data
+
+# Parse the markdown
+parsed_object = parse_markdown(markdown)
+
+# Render the template
+rendered = template.render(categories=parsed_object)
+
+# Save the output to a file
+with open("bookmarks.html", "w") as f:
+    f.write(rendered)
+
+print(rendered)


### PR DESCRIPTION
A script that turns the 'readme.md' into a netscape bookmark file, that then can be imported into your browser.

The `bookmarks.html` could be omitted or auto-generated with Github-Actions.

Just a small idea. Feel free to reject if you don't see it fit.

<img width="780" alt="image" src="https://github.com/user-attachments/assets/df7e0814-4d3f-4b1b-baa5-1bfd1d06ad80">
